### PR TITLE
Add partition name/ID to scheduler and DAO Queue, Application, Node objects

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -604,6 +604,7 @@ func (cc *ClusterContext) addNode(nodeInfo *si.NodeInfo, schedulable bool) error
 			zap.String("partitionName", sn.Partition))
 		return err
 	}
+	sn.PartitionID = partition.ID
 
 	err := partition.AddNode(sn)
 	sn.SendNodeAddedEvent()

--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -537,6 +537,9 @@ func (cc *ClusterContext) handleRMUpdateApplicationEvent(event *rmevent.RMUpdate
 		acceptedApps = append(acceptedApps, &si.AcceptedApplication{
 			ApplicationID: schedApp.ApplicationID,
 		})
+
+		schedApp.PartitionID = partition.ID
+
 		log.Log(log.SchedContext).Info("Added application to partition",
 			zap.String("applicationID", app.ApplicationID),
 			zap.String("partitionName", app.PartitionName),

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -209,7 +209,7 @@ func (app *Application) dao() *dao.ApplicationDAOInfo {
 }
 
 func NewApplication(siApp *si.AddApplicationRequest, ugi security.UserGroup, eventHandler handler.EventHandler, rmID string) *Application {
-	id, _ := ulid.New(ms, entropy)
+	id, _ := ulid.New(Ms, Entropy)
 	app := &Application{
 		ID:                    id.String(),
 		ApplicationID:         siApp.ApplicationID,

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -126,8 +126,8 @@ type Application struct {
 	appEvents             *schedEvt.ApplicationEvents
 	sendStateChangeEvents bool // whether to send state-change events or not (simplifies testing)
 
+	snapshotLock locking.Mutex
 	snapshot     bytes.Buffer
-	snapshotLock locking.RWMutex
 
 	locking.RWMutex
 }

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -126,8 +126,8 @@ type Application struct {
 	appEvents             *schedEvt.ApplicationEvents
 	sendStateChangeEvents bool // whether to send state-change events or not (simplifies testing)
 
-	snapshot        bytes.Buffer
-	appSnapshotLock locking.RWMutex
+	snapshot     bytes.Buffer
+	snapshotLock locking.RWMutex
 
 	locking.RWMutex
 }
@@ -156,8 +156,8 @@ func (sa *Application) GetApplicationSummary(rmID string) *ApplicationSummary {
 }
 
 func (sa *Application) daoSnapshot() string {
-	sa.appSnapshotLock.Lock()
-	defer sa.appSnapshotLock.Unlock()
+	sa.snapshotLock.Lock()
+	defer sa.snapshotLock.Unlock()
 
 	if err := json.NewEncoder(&sa.snapshot).Encode(sa.dao()); err != nil {
 		// TODO: log error

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -84,6 +84,7 @@ type Application struct {
 	ID             string            // a formatted ULID
 	ApplicationID  string            // application ID
 	Partition      string            // partition Name
+	PartitionID    string            // partition ID (a formatted ULID)
 	SubmissionTime time.Time         // time application was submitted
 	tags           map[string]string // application tags used in scheduling
 
@@ -185,6 +186,7 @@ func (app *Application) dao() *dao.ApplicationDAOInfo {
 		MaxUsedResource:     app.maxAllocatedResource.Clone().DAOMap(),
 		PendingResource:     app.pending.Clone().DAOMap(),
 		Partition:           common.GetPartitionNameWithoutClusterID(app.Partition),
+		PartitionID:         app.PartitionID,
 		QueueName:           app.queuePath,
 		SubmissionTime:      app.SubmissionTime.UnixNano(),
 		FinishedTime:        common.ZeroTimeInUnixNano(app.finishedTime),
@@ -258,8 +260,8 @@ func (sa *Application) String() string {
 	if sa == nil {
 		return "application is nil"
 	}
-	return fmt.Sprintf("applicationID: %s, Partition: %s, SubmissionTime: %x, State: %s, ID: %s",
-		sa.ApplicationID, sa.Partition, sa.SubmissionTime, sa.stateMachine.Current(), sa.ID)
+	return fmt.Sprintf("applicationID: %s, Partition: %s, Partition ID: %s, SubmissionTime: %x, State: %s, ID: %s",
+		sa.ApplicationID, sa.Partition, sa.PartitionID, sa.SubmissionTime, sa.stateMachine.Current(), sa.ID)
 }
 
 func (sa *Application) SetState(state string) {

--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -207,8 +207,9 @@ func (app *Application) dao() *dao.ApplicationDAOInfo {
 }
 
 func NewApplication(siApp *si.AddApplicationRequest, ugi security.UserGroup, eventHandler handler.EventHandler, rmID string) *Application {
+	id, _ := ulid.New(ms, entropy)
 	app := &Application{
-		ID:                    ulid.Make().String(),
+		ID:                    id.String(),
 		ApplicationID:         siApp.ApplicationID,
 		Partition:             siApp.PartitionName,
 		SubmissionTime:        time.Now(),

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -2596,7 +2596,7 @@ func TestGetOutstandingRequests(t *testing.T) {
 	allocationAsk2.SetSchedulingAttempted(true)
 
 	// Create an Application instance
-	id, _ := ulid.New(ms, entropy)
+	id, _ := ulid.New(Ms, Entropy)
 	app := &Application{
 		ID:            id.String(),
 		ApplicationID: "app-1",
@@ -2661,7 +2661,7 @@ func TestGetOutstandingRequests_NoSchedulingAttempt(t *testing.T) {
 	allocationAsk2.SetSchedulingAttempted(true)
 	allocationAsk4.SetSchedulingAttempted(true)
 
-	id, _ := ulid.New(ms, entropy)
+	id, _ := ulid.New(Ms, Entropy)
 	app := &Application{
 		ID:            id.String(),
 		ApplicationID: "app-1",
@@ -2702,7 +2702,7 @@ func TestGetOutstandingRequests_RequestTriggeredPreemptionHasRequiredNode(t *tes
 	allocationAsk2.SetRequiredNode("node-1")
 	allocationAsk3.SetRequiredNode("node-1") // hasn't triggered scaling, has required node --> not selected
 
-	id, _ := ulid.New(ms, entropy)
+	id, _ := ulid.New(Ms, Entropy)
 	app := &Application{
 		ID:            id.String(),
 		ApplicationID: "app-1",
@@ -2736,7 +2736,7 @@ func TestGetOutstandingRequests_AskReplaceable(t *testing.T) {
 	allocationAsk1.taskGroupName = "testgroup"
 	allocationAsk2.taskGroupName = "testgroup"
 
-	id, _ := ulid.New(ms, entropy)
+	id, _ := ulid.New(Ms, Entropy)
 	app := &Application{
 		ID:            id.String(),
 		ApplicationID: "app-1",

--- a/pkg/scheduler/objects/application_test.go
+++ b/pkg/scheduler/objects/application_test.go
@@ -2596,8 +2596,9 @@ func TestGetOutstandingRequests(t *testing.T) {
 	allocationAsk2.SetSchedulingAttempted(true)
 
 	// Create an Application instance
+	id, _ := ulid.New(ms, entropy)
 	app := &Application{
-		ID:            ulid.Make().String(),
+		ID:            id.String(),
 		ApplicationID: "app-1",
 		queuePath:     "default",
 	}
@@ -2659,8 +2660,10 @@ func TestGetOutstandingRequests_NoSchedulingAttempt(t *testing.T) {
 	allocationAsk4 := newAllocationAsk("alloc-4", "app-1", res)
 	allocationAsk2.SetSchedulingAttempted(true)
 	allocationAsk4.SetSchedulingAttempted(true)
+
+	id, _ := ulid.New(ms, entropy)
 	app := &Application{
-		ID:            ulid.Make().String(),
+		ID:            id.String(),
 		ApplicationID: "app-1",
 		queuePath:     "default",
 	}
@@ -2699,8 +2702,9 @@ func TestGetOutstandingRequests_RequestTriggeredPreemptionHasRequiredNode(t *tes
 	allocationAsk2.SetRequiredNode("node-1")
 	allocationAsk3.SetRequiredNode("node-1") // hasn't triggered scaling, has required node --> not selected
 
+	id, _ := ulid.New(ms, entropy)
 	app := &Application{
-		ID:            ulid.Make().String(),
+		ID:            id.String(),
 		ApplicationID: "app-1",
 		queuePath:     "default",
 	}
@@ -2732,8 +2736,9 @@ func TestGetOutstandingRequests_AskReplaceable(t *testing.T) {
 	allocationAsk1.taskGroupName = "testgroup"
 	allocationAsk2.taskGroupName = "testgroup"
 
+	id, _ := ulid.New(ms, entropy)
 	app := &Application{
-		ID:            ulid.Make().String(),
+		ID:            id.String(),
 		ApplicationID: "app-1",
 		queuePath:     "default",
 	}

--- a/pkg/scheduler/objects/init.go
+++ b/pkg/scheduler/objects/init.go
@@ -1,0 +1,41 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package objects
+
+import (
+	"sync"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"golang.org/x/exp/rand"
+)
+
+var (
+	once    sync.Once
+	entropy *rand.Rand
+	ms      uint64
+)
+
+func init() {
+	once.Do(func() {
+		entropy = rand.New(new(rand.LockedSource))
+		entropy.Seed(uint64(time.Now().UnixMicro()))
+		ms = ulid.Timestamp(time.Now())
+	})
+}

--- a/pkg/scheduler/objects/init.go
+++ b/pkg/scheduler/objects/init.go
@@ -32,6 +32,6 @@ var (
 
 func init() {
 	entropy = rand.New(new(rand.LockedSource))
-	entropy.Seed(uint64(time.Now().UnixMicro()))
+	entropy.Seed(uint64(time.Now().UnixNano()))
 	ms = ulid.Timestamp(time.Now())
 }

--- a/pkg/scheduler/objects/init.go
+++ b/pkg/scheduler/objects/init.go
@@ -26,12 +26,12 @@ import (
 )
 
 var (
-	entropy *rand.Rand
-	ms      uint64
+	Entropy *rand.Rand
+	Ms      uint64
 )
 
 func init() {
-	entropy = rand.New(new(rand.LockedSource))
-	entropy.Seed(uint64(time.Now().UnixNano()))
-	ms = ulid.Timestamp(time.Now())
+	Entropy = rand.New(new(rand.LockedSource))
+	Entropy.Seed(uint64(time.Now().UnixNano()))
+	Ms = ulid.Timestamp(time.Now())
 }

--- a/pkg/scheduler/objects/init.go
+++ b/pkg/scheduler/objects/init.go
@@ -19,7 +19,6 @@
 package objects
 
 import (
-	"sync"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -27,15 +26,12 @@ import (
 )
 
 var (
-	once    sync.Once
 	entropy *rand.Rand
 	ms      uint64
 )
 
 func init() {
-	once.Do(func() {
-		entropy = rand.New(new(rand.LockedSource))
-		entropy.Seed(uint64(time.Now().UnixMicro()))
-		ms = ulid.Timestamp(time.Now())
-	})
+	entropy = rand.New(new(rand.LockedSource))
+	entropy.Seed(uint64(time.Now().UnixMicro()))
+	ms = ulid.Timestamp(time.Now())
 }

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -110,8 +110,9 @@ func NewNode(proto *si.NodeInfo) *Node {
 		return nil
 	}
 
+	id, _ := ulid.New(ms, entropy)
 	sn := &Node{
-		ID:                ulid.Make().String(),
+		ID:                id.String(),
 		NodeID:            proto.NodeID,
 		reservations:      make(map[string]*reservation),
 		totalResource:     resources.NewResourceFromProto(proto.SchedulableResource),

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -64,8 +64,8 @@ type Node struct {
 	listeners    []NodeListener          // a list of node listeners
 	nodeEvents   *schedEvt.NodeEvents
 
+	snapshotLock locking.Mutex
 	snapshot     bytes.Buffer
-	snapshotLock locking.RWMutex
 
 	locking.RWMutex
 }

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -112,7 +112,7 @@ func NewNode(proto *si.NodeInfo) *Node {
 		return nil
 	}
 
-	id, _ := ulid.New(ms, entropy)
+	id, _ := ulid.New(Ms, Entropy)
 	sn := &Node{
 		ID:                id.String(),
 		NodeID:            proto.NodeID,

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -45,11 +45,12 @@ const (
 type Node struct {
 	// Fields for fast access These fields are considered read only.
 	// Values should only be set when creating a new node and never changed.
-	ID        string
-	NodeID    string
-	Hostname  string
-	Rackname  string
-	Partition string
+	ID          string
+	NodeID      string
+	Hostname    string
+	Rackname    string
+	Partition   string
+	PartitionID string
 
 	// Private fields need protection
 	attributes        map[string]string
@@ -77,6 +78,7 @@ func (node *Node) dao() *dao.NodeDAOInfo {
 		HostName:           node.Hostname,
 		RackName:           node.Rackname,
 		Partition:          node.Partition,
+		PartitionID:        node.PartitionID,
 		Attributes:         node.GetAttributes(),
 		Capacity:           node.totalResource.Clone().DAOMap(),
 		Occupied:           node.occupiedResource.Clone().DAOMap(),
@@ -140,8 +142,9 @@ func (sn *Node) String() string {
 	if sn == nil {
 		return "node is nil"
 	}
-	return fmt.Sprintf("NodeID %s, Partition %s, Schedulable %t, Total %s, Allocated %s, #allocations %d, ID %s",
-		sn.NodeID, sn.Partition, sn.schedulable, sn.totalResource, sn.allocatedResource, len(sn.allocations), sn.ID)
+	return fmt.Sprintf("NodeID %s, Partition %s, PartitionID %s, Schedulable %t, Total %s, Allocated %s, #allocations %d, ID %s",
+		sn.NodeID, sn.Partition, sn.PartitionID, sn.schedulable, sn.totalResource, sn.allocatedResource,
+		len(sn.allocations), sn.ID)
 }
 
 // Set the attributes and fast access fields.

--- a/pkg/scheduler/objects/node.go
+++ b/pkg/scheduler/objects/node.go
@@ -64,8 +64,8 @@ type Node struct {
 	listeners    []NodeListener          // a list of node listeners
 	nodeEvents   *schedEvt.NodeEvents
 
-	snapshot         bytes.Buffer
-	nodeSnapshotLock locking.RWMutex
+	snapshot     bytes.Buffer
+	snapshotLock locking.RWMutex
 
 	locking.RWMutex
 }
@@ -92,8 +92,8 @@ func (node *Node) dao() *dao.NodeDAOInfo {
 }
 
 func (node *Node) daoSnapshot() string {
-	node.nodeSnapshotLock.Lock()
-	defer node.nodeSnapshotLock.Unlock()
+	node.snapshotLock.Lock()
+	defer node.snapshotLock.Unlock()
 
 	if err := json.NewEncoder(&node.snapshot).Encode(node.dao()); err != nil {
 		// TODO: handle error

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -707,7 +707,7 @@ func (sq *Queue) GetPartitionQueueDAOInfo(include bool) dao.PartitionQueueDAOInf
 	}
 	queueInfo.ID = sq.ID
 	queueInfo.QueueName = sq.QueuePath
-	queueInfo.Partition = sq.Partition
+	queueInfo.Partition = common.GetPartitionNameWithoutClusterID(sq.Partition)
 	queueInfo.Status = sq.stateMachine.Current()
 	queueInfo.PendingResource = sq.pending.DAOMap()
 	queueInfo.MaxResource = sq.maxResource.DAOMap()

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -115,7 +115,7 @@ func (sq *Queue) daoSnapshot() string {
 
 // newBlankQueue creates a new empty queue objects with all values initialised.
 func newBlankQueue() *Queue {
-	id, _ := ulid.New(ms, entropy)
+	id, _ := ulid.New(Ms, Entropy)
 	return &Queue{
 		ID:                     id.String(),
 		children:               make(map[string]*Queue),

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -56,6 +56,7 @@ type Queue struct {
 	ID        string // A formatted ULID
 	QueuePath string // Fully qualified path for the queue
 	Name      string // Queue name as in the config etc.
+	Partition string // Partition in which this queue resides
 
 	// Private fields need protection
 	sortType            policies.SortPolicy       // How applications (leaf) or queues (parents) are sorted
@@ -93,15 +94,15 @@ type Queue struct {
 	template               *template.Template
 	queueEvents            *schedEvt.QueueEvents
 
-	snapshot          bytes.Buffer
-	queueSnapshotLock locking.RWMutex
+	snapshot     bytes.Buffer
+	snapshotLock locking.RWMutex
 
 	locking.RWMutex
 }
 
 func (sq *Queue) daoSnapshot() string {
-	sq.queueSnapshotLock.Lock()
-	defer sq.queueSnapshotLock.Unlock()
+	sq.snapshotLock.Lock()
+	defer sq.snapshotLock.Unlock()
 
 	if err := json.NewEncoder(&sq.snapshot).Encode(sq.getPartitionQueueDAOInfo(false)); err != nil {
 		// TODO: log error
@@ -156,6 +157,7 @@ func NewConfiguredQueue(conf configs.QueueConfig, parent *Queue) (*Queue, error)
 		sq.mergeProperties(parent.getProperties(), conf.Properties)
 		sq.UpdateQueueProperties()
 		sq.QueuePath = parent.QueuePath + configs.DOT + sq.Name
+		sq.Partition = parent.Partition
 		err := parent.addChildQueue(sq)
 		if err != nil {
 			return nil, errors.Join(errors.New("configured queue creation failed: "), err)
@@ -705,6 +707,7 @@ func (sq *Queue) GetPartitionQueueDAOInfo(include bool) dao.PartitionQueueDAOInf
 	}
 	queueInfo.ID = sq.ID
 	queueInfo.QueueName = sq.QueuePath
+	queueInfo.Partition = sq.Partition
 	queueInfo.Status = sq.stateMachine.Current()
 	queueInfo.PendingResource = sq.pending.DAOMap()
 	queueInfo.MaxResource = sq.maxResource.DAOMap()
@@ -754,6 +757,7 @@ func (sq *Queue) getPartitionQueueDAOInfo(include bool) dao.PartitionQueueDAOInf
 	}
 	queueInfo.ID = sq.ID
 	queueInfo.QueueName = sq.QueuePath
+	queueInfo.Partition = sq.Partition
 	queueInfo.Status = sq.stateMachine.Current()
 	queueInfo.PendingResource = sq.pending.DAOMap()
 	queueInfo.MaxResource = sq.maxResource.DAOMap()
@@ -1786,8 +1790,8 @@ func (sq *Queue) updatePreemptingResourceMetrics() {
 func (sq *Queue) String() string {
 	sq.RLock()
 	defer sq.RUnlock()
-	return fmt.Sprintf("{QueuePath: %s, State: %s, StateTime: %x, MaxResource: %s}",
-		sq.QueuePath, sq.stateMachine.Current(), sq.stateTime, sq.maxResource)
+	return fmt.Sprintf("{QueuePath: %s, State: %s, StateTime: %x, MaxResource: %s, Partition: %s}",
+		sq.QueuePath, sq.stateMachine.Current(), sq.stateTime, sq.maxResource, sq.Partition)
 }
 
 // incRunningApps increments the number of running applications for this queue (recursively).

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -53,10 +53,10 @@ var (
 
 // Queue structure inside Scheduler
 type Queue struct {
-	ID        string // A formatted ULID
-	QueuePath string // Fully qualified path for the queue
-	Name      string // Queue name as in the config etc.
-	Partition string // Partition in which this queue resides
+	ID          string // A formatted ULID
+	QueuePath   string // Fully qualified path for the queue
+	Name        string // Queue name as in the config etc.
+	PartitionID string // Partition ID (not name) in which this queue resides
 
 	// Private fields need protection
 	sortType            policies.SortPolicy       // How applications (leaf) or queues (parents) are sorted
@@ -158,7 +158,7 @@ func NewConfiguredQueue(conf configs.QueueConfig, parent *Queue) (*Queue, error)
 		sq.mergeProperties(parent.getProperties(), conf.Properties)
 		sq.UpdateQueueProperties()
 		sq.QueuePath = parent.QueuePath + configs.DOT + sq.Name
-		sq.Partition = parent.Partition
+		sq.PartitionID = parent.PartitionID
 		err := parent.addChildQueue(sq)
 		if err != nil {
 			return nil, errors.Join(errors.New("configured queue creation failed: "), err)
@@ -708,7 +708,7 @@ func (sq *Queue) GetPartitionQueueDAOInfo(include bool) dao.PartitionQueueDAOInf
 	}
 	queueInfo.ID = sq.ID
 	queueInfo.QueueName = sq.QueuePath
-	queueInfo.Partition = common.GetPartitionNameWithoutClusterID(sq.Partition)
+	queueInfo.PartitionID = sq.PartitionID
 	queueInfo.Status = sq.stateMachine.Current()
 	queueInfo.PendingResource = sq.pending.DAOMap()
 	queueInfo.MaxResource = sq.maxResource.DAOMap()
@@ -758,7 +758,7 @@ func (sq *Queue) getPartitionQueueDAOInfo(include bool) dao.PartitionQueueDAOInf
 	}
 	queueInfo.ID = sq.ID
 	queueInfo.QueueName = sq.QueuePath
-	queueInfo.Partition = common.GetPartitionNameWithoutClusterID(sq.Partition)
+	queueInfo.PartitionID = sq.PartitionID
 	queueInfo.Status = sq.stateMachine.Current()
 	queueInfo.PendingResource = sq.pending.DAOMap()
 	queueInfo.MaxResource = sq.maxResource.DAOMap()
@@ -1792,7 +1792,7 @@ func (sq *Queue) String() string {
 	sq.RLock()
 	defer sq.RUnlock()
 	return fmt.Sprintf("{QueuePath: %s, State: %s, StateTime: %x, MaxResource: %s, Partition: %s}",
-		sq.QueuePath, sq.stateMachine.Current(), sq.stateTime, sq.maxResource, sq.Partition)
+		sq.QueuePath, sq.stateMachine.Current(), sq.stateTime, sq.maxResource, sq.PartitionID)
 }
 
 // incRunningApps increments the number of running applications for this queue (recursively).

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -115,8 +115,9 @@ func (sq *Queue) daoSnapshot() string {
 
 // newBlankQueue creates a new empty queue objects with all values initialised.
 func newBlankQueue() *Queue {
+	id, _ := ulid.New(ms, entropy)
 	return &Queue{
-		ID:                     ulid.Make().String(),
+		ID:                     id.String(),
 		children:               make(map[string]*Queue),
 		childPriorities:        make(map[string]int32),
 		applications:           make(map[string]*Application),
@@ -757,7 +758,7 @@ func (sq *Queue) getPartitionQueueDAOInfo(include bool) dao.PartitionQueueDAOInf
 	}
 	queueInfo.ID = sq.ID
 	queueInfo.QueueName = sq.QueuePath
-	queueInfo.Partition = sq.Partition
+	queueInfo.Partition = common.GetPartitionNameWithoutClusterID(sq.Partition)
 	queueInfo.Status = sq.stateMachine.Current()
 	queueInfo.PendingResource = sq.pending.DAOMap()
 	queueInfo.MaxResource = sq.maxResource.DAOMap()

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -94,8 +94,8 @@ type Queue struct {
 	template               *template.Template
 	queueEvents            *schedEvt.QueueEvents
 
+	snapshotLock locking.Mutex
 	snapshot     bytes.Buffer
-	snapshotLock locking.RWMutex
 
 	locking.RWMutex
 }

--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -115,8 +115,9 @@ func (sq *Queue) daoSnapshot() string {
 
 // newBlankQueue creates a new empty queue objects with all values initialised.
 func newBlankQueue() *Queue {
+	id, _ := ulid.New(ms, entropy)
 	return &Queue{
-		ID:                     ulid.Make().String(),
+		ID:                     id.String(),
 		children:               make(map[string]*Queue),
 		childPriorities:        make(map[string]int32),
 		applications:           make(map[string]*Application),
@@ -755,7 +756,7 @@ func (sq *Queue) getPartitionQueueDAOInfo(include bool) dao.PartitionQueueDAOInf
 	}
 	queueInfo.ID = sq.ID
 	queueInfo.QueueName = sq.QueuePath
-	queueInfo.Partition = sq.Partition
+	queueInfo.Partition = common.GetPartitionNameWithoutClusterID(sq.Partition)
 	queueInfo.Status = sq.stateMachine.Current()
 	queueInfo.PendingResource = sq.pending.DAOMap()
 	queueInfo.MaxResource = sq.maxResource.DAOMap()

--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -171,8 +171,9 @@ func newNodeRes(nodeID string, total *resources.Resource) *Node {
 }
 
 func newNodeInternal(nodeID string, total, occupied *resources.Resource) *Node {
+	id, _ := ulid.New(ms, entropy)
 	sn := &Node{
-		ID:                ulid.Make().String(),
+		ID:                id.String(),
 		NodeID:            nodeID,
 		Hostname:          "",
 		Rackname:          "",

--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -171,7 +171,7 @@ func newNodeRes(nodeID string, total *resources.Resource) *Node {
 }
 
 func newNodeInternal(nodeID string, total, occupied *resources.Resource) *Node {
-	id, _ := ulid.New(ms, entropy)
+	id, _ := ulid.New(Ms, Entropy)
 	sn := &Node{
 		ID:                id.String(),
 		NodeID:            nodeID,

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -89,8 +89,10 @@ func newPartitionContext(conf configs.PartitionConfig, rmID string, cc *ClusterC
 			zap.Any("cluster context", cc))
 		return nil, fmt.Errorf("partition cannot be created without name or RM, one is not set")
 	}
+
+	id, _ := ulid.New(objects.Ms, objects.Entropy)
 	pc := &PartitionContext{
-		ID:                    ulid.Make().String(),
+		ID:                    id.String(),
 		Name:                  conf.Name,
 		RmID:                  rmID,
 		stateMachine:          objects.NewObjectState(),

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -118,6 +118,8 @@ func (pc *PartitionContext) initialPartitionFromConfig(conf configs.PartitionCon
 	if pc.root, err = objects.NewConfiguredQueue(queueConf, nil); err != nil {
 		return err
 	}
+	pc.root.Partition = pc.Name
+
 	// recursively add the queues to the root
 	if err = pc.addQueue(queueConf.Queues, pc.root); err != nil {
 		return err
@@ -205,6 +207,7 @@ func (pc *PartitionContext) addQueue(conf []configs.QueueConfig, parent *objects
 			if err != nil {
 				return err
 			}
+			thisQueue.Partition = pc.Name
 		}
 	}
 	return nil

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -121,6 +121,8 @@ func (pc *PartitionContext) initialPartitionFromConfig(conf configs.PartitionCon
 	if pc.root, err = objects.NewConfiguredQueue(queueConf, nil); err != nil {
 		return err
 	}
+	pc.root.Partition = pc.Name
+
 	// recursively add the queues to the root
 	if err = pc.addQueue(queueConf.Queues, pc.root); err != nil {
 		return err
@@ -208,6 +210,7 @@ func (pc *PartitionContext) addQueue(conf []configs.QueueConfig, parent *objects
 			if err != nil {
 				return err
 			}
+			thisQueue.Partition = pc.Name
 		}
 	}
 	return nil

--- a/pkg/scheduler/partition.go
+++ b/pkg/scheduler/partition.go
@@ -121,7 +121,7 @@ func (pc *PartitionContext) initialPartitionFromConfig(conf configs.PartitionCon
 	if pc.root, err = objects.NewConfiguredQueue(queueConf, nil); err != nil {
 		return err
 	}
-	pc.root.Partition = pc.Name
+	pc.root.PartitionID = pc.ID
 
 	// recursively add the queues to the root
 	if err = pc.addQueue(queueConf.Queues, pc.root); err != nil {
@@ -210,7 +210,7 @@ func (pc *PartitionContext) addQueue(conf []configs.QueueConfig, parent *objects
 			if err != nil {
 				return err
 			}
-			thisQueue.Partition = pc.Name
+			thisQueue.PartitionID = pc.ID
 		}
 	}
 	return nil
@@ -498,7 +498,7 @@ func (pc *PartitionContext) getQueueInternal(name string) *objects.Queue {
 // GetPartitionQueues builds the queue info for the whole queue structure to pass to the webservice
 func (pc *PartitionContext) GetPartitionQueues() dao.PartitionQueueDAOInfo {
 	partitionQueueDAOInfo := pc.root.GetPartitionQueueDAOInfo(true)
-	partitionQueueDAOInfo.Partition = common.GetPartitionNameWithoutClusterID(pc.Name)
+	partitionQueueDAOInfo.PartitionID = pc.ID
 	return partitionQueueDAOInfo
 }
 

--- a/pkg/webservice/dao/application_info.go
+++ b/pkg/webservice/dao/application_info.go
@@ -32,8 +32,9 @@ type ApplicationDAOInfo struct {
 	UsedResource        map[string]int64           `json:"usedResource,omitempty"`
 	MaxUsedResource     map[string]int64           `json:"maxUsedResource,omitempty"`
 	PendingResource     map[string]int64           `json:"pendingResource,omitempty"`
-	Partition           string                     `json:"partition"` // no omitempty, partition should not be empty
-	QueueName           string                     `json:"queueName"` // no omitempty, queue name should not be empty
+	Partition           string                     `json:"partition"`    // no omitempty, partition should not be empty
+	PartitionID         string                     `json:"partition_id"` // no omitempty partition id should not be empty
+	QueueName           string                     `json:"queueName"`    // no omitempty, queue name should not be empty
 	SubmissionTime      int64                      `json:"submissionTime,omitempty"`
 	FinishedTime        *int64                     `json:"finishedTime,omitempty"`
 	Requests            []*AllocationAskDAOInfo    `json:"requests,omitempty"`

--- a/pkg/webservice/dao/node_info.go
+++ b/pkg/webservice/dao/node_info.go
@@ -28,7 +28,8 @@ type NodeDAOInfo struct {
 	NodeID             string                      `json:"nodeID"` // no omitempty, node id should not be empty
 	HostName           string                      `json:"hostName,omitempty"`
 	RackName           string                      `json:"rackName,omitempty"`
-	Partition          string                      `json:"partition"` // no omitempty, partition should not be empty
+	Partition          string                      `json:"partition"`    // no omitempty, partition should not be empty
+	PartitionID        string                      `json:"partition_id"` // no omitempty, partition ID should not be empty
 	Attributes         map[string]string           `json:"attributes,omitempty"`
 	Capacity           map[string]int64            `json:"capacity,omitempty"`
 	Allocated          map[string]int64            `json:"allocated,omitempty"`

--- a/pkg/webservice/dao/queue_info.go
+++ b/pkg/webservice/dao/queue_info.go
@@ -28,7 +28,7 @@ type PartitionQueueDAOInfo struct {
 	ID                     string                  `json:"id"`        // no omitempty, id should not be empty
 	QueueName              string                  `json:"queuename"` // no omitempty, queue name should not be empty
 	Status                 string                  `json:"status,omitempty"`
-	Partition              string                  `json:"partition"` // no omitempty, queue name should not be empty
+	PartitionID            string                  `json:"partition_id"` // no omitempty, partition id should not be empty
 	PendingResource        map[string]int64        `json:"pendingResource,omitempty"`
 	MaxResource            map[string]int64        `json:"maxResource,omitempty"`
 	GuaranteedResource     map[string]int64        `json:"guaranteedResource,omitempty"`

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -330,6 +330,7 @@ func getApplicationDAO(app *objects.Application, summary *objects.ApplicationSum
 		MaxUsedResource:     app.GetMaxAllocatedResource().DAOMap(),
 		PendingResource:     app.GetPendingResource().DAOMap(),
 		Partition:           common.GetPartitionNameWithoutClusterID(app.Partition),
+		PartitionID:         app.PartitionID,
 		QueueName:           app.GetQueuePath(),
 		SubmissionTime:      app.SubmissionTime.UnixNano(),
 		FinishedTime:        common.ZeroTimeInUnixNano(app.FinishedTime()),
@@ -989,6 +990,7 @@ func getPartitionInfoDAO(lists map[string]*scheduler.PartitionContext) []*dao.Pa
 		partitionInfo := &dao.PartitionInfo{}
 		partitionInfo.ClusterID = partitionContext.RmID
 		partitionInfo.Name = common.GetPartitionNameWithoutClusterID(partitionContext.Name)
+		partitionInfo.ID = partitionContext.ID
 		partitionInfo.State = partitionContext.GetCurrentState()
 		partitionInfo.LastStateTransitionTime = partitionContext.GetStateTime().UnixNano()
 

--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -402,6 +402,7 @@ func getNodeDAO(node *objects.Node) *dao.NodeDAOInfo {
 		HostName:           node.Hostname,
 		RackName:           node.Rackname,
 		Partition:          node.Partition,
+		PartitionID:        node.PartitionID,
 		Attributes:         node.GetAttributes(),
 		Capacity:           node.GetCapacity().DAOMap(),
 		Occupied:           node.GetOccupiedResource().DAOMap(),

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1150,12 +1150,12 @@ func TestGetPartitionQueuesHandler(t *testing.T) {
 	// assert child root.a fields
 	assert.Equal(t, len(partitionQueuesDao.Children), 1)
 	child := &partitionQueuesDao.Children[0]
-	assertPartitionQueueDaoInfo(t, child, "root.a", "", maxResource.DAOMap(), guaranteedResource.DAOMap(), false, true, "root", &templateInfo)
+	assertPartitionQueueDaoInfo(t, child, "root.a", configs.DefaultPartition, maxResource.DAOMap(), guaranteedResource.DAOMap(), false, true, "root", &templateInfo)
 
 	// assert child root.a.a1 fields
 	assert.Equal(t, len(partitionQueuesDao.Children[0].Children), 1)
 	child = &partitionQueuesDao.Children[0].Children[0]
-	assertPartitionQueueDaoInfo(t, child, "root.a.a1", "", maxResource.DAOMap(), guaranteedResource.DAOMap(), true, true, "root.a", nil)
+	assertPartitionQueueDaoInfo(t, child, "root.a.a1", configs.DefaultPartition, maxResource.DAOMap(), guaranteedResource.DAOMap(), true, true, "root.a", nil)
 
 	// test partition not exists
 	req, err = createRequest(t, "/ws/v1/partition/default/queues", map[string]string{"partition": "notexists"})
@@ -1176,7 +1176,9 @@ func assertPartitionQueueDaoInfo(t *testing.T, partitionQueueDAOInfo *dao.Partit
 	assert.Assert(t, partitionQueueDAOInfo.ID != "")
 	assert.Equal(t, partitionQueueDAOInfo.QueueName, queueName)
 	assert.Equal(t, partitionQueueDAOInfo.Status, objects.Active.String())
-	assert.Equal(t, partitionQueueDAOInfo.Partition, partition)
+	assert.Equal(t, partitionQueueDAOInfo.Partition, common.GetPartitionNameWithoutClusterID(partition),
+		"DAO partition is %s and partition-without-clusterID is %s",
+		partitionQueueDAOInfo.Partition, common.GetPartitionNameWithoutClusterID(partition))
 	assert.Assert(t, partitionQueueDAOInfo.PendingResource == nil)
 	assert.DeepEqual(t, partitionQueueDAOInfo.MaxResource, maxResource)
 	assert.DeepEqual(t, partitionQueueDAOInfo.GuaranteedResource, gResource)

--- a/pkg/webservice/handlers_test.go
+++ b/pkg/webservice/handlers_test.go
@@ -1176,9 +1176,7 @@ func assertPartitionQueueDaoInfo(t *testing.T, partitionQueueDAOInfo *dao.Partit
 	assert.Assert(t, partitionQueueDAOInfo.ID != "")
 	assert.Equal(t, partitionQueueDAOInfo.QueueName, queueName)
 	assert.Equal(t, partitionQueueDAOInfo.Status, objects.Active.String())
-	assert.Equal(t, partitionQueueDAOInfo.Partition, common.GetPartitionNameWithoutClusterID(partition),
-		"DAO partition is %s and partition-without-clusterID is %s",
-		partitionQueueDAOInfo.Partition, common.GetPartitionNameWithoutClusterID(partition))
+	assert.Equal(t, partitionQueueDAOInfo.Partition, common.GetPartitionNameWithoutClusterID(partition))
 	assert.Assert(t, partitionQueueDAOInfo.PendingResource == nil)
 	assert.DeepEqual(t, partitionQueueDAOInfo.MaxResource, maxResource)
 	assert.DeepEqual(t, partitionQueueDAOInfo.GuaranteedResource, gResource)


### PR DESCRIPTION
This adds a `Partition` string member to the Yunikorn scheduler `Queue` object, as well as the external DAO Queue object. A `PartitionID` string member is added to the Queue, Node, and Application objects as well.

Other miscellaneous fixes:
- shorten the names of the DAO snapshot mutexes for Application, Queue, and Node
- use a single, thread-source source of random-ness for ULID generation

Fixes https://github.com/G-Research/yunikorn-history-server/issues/291