### PR TITLE
Add queue id to application dao

### DIFF
--- a/pkg/scheduler/objects/application.go
+++ b/pkg/scheduler/objects/application.go
@@ -178,6 +178,10 @@ func (app *Application) dao() *dao.ApplicationDAOInfo {
 	resourceUsage := app.usedResource.Clone()
 	preemptedUsage := app.preemptedResource.Clone()
 	placeHolderUsage := app.placeholderResource.Clone()
+	var qID *string
+	if app.queue != nil {
+		qID = &app.queue.ID
+	}
 
 	return &dao.ApplicationDAOInfo{
 		ID:                  app.ID,
@@ -187,6 +191,7 @@ func (app *Application) dao() *dao.ApplicationDAOInfo {
 		PendingResource:     app.pending.Clone().DAOMap(),
 		Partition:           common.GetPartitionNameWithoutClusterID(app.Partition),
 		PartitionID:         app.PartitionID,
+		QueueID:             qID,
 		QueueName:           app.queuePath,
 		SubmissionTime:      app.SubmissionTime.UnixNano(),
 		FinishedTime:        common.ZeroTimeInUnixNano(app.finishedTime),

--- a/pkg/webservice/dao/application_info.go
+++ b/pkg/webservice/dao/application_info.go
@@ -34,6 +34,7 @@ type ApplicationDAOInfo struct {
 	PendingResource     map[string]int64           `json:"pendingResource,omitempty"`
 	Partition           string                     `json:"partition"`    // no omitempty, partition should not be empty
 	PartitionID         string                     `json:"partition_id"` // no omitempty partition id should not be empty
+	QueueID             *string                    `json:"queueID"`      // no omitempty, queue id should not be empty
 	QueueName           string                     `json:"queueName"`    // no omitempty, queue name should not be empty
 	SubmissionTime      int64                      `json:"submissionTime,omitempty"`
 	FinishedTime        *int64                     `json:"finishedTime,omitempty"`

--- a/pkg/webservice/dao/application_info.go
+++ b/pkg/webservice/dao/application_info.go
@@ -34,8 +34,8 @@ type ApplicationDAOInfo struct {
 	PendingResource     map[string]int64           `json:"pendingResource,omitempty"`
 	Partition           string                     `json:"partition"`    // no omitempty, partition should not be empty
 	PartitionID         string                     `json:"partition_id"` // no omitempty partition id should not be empty
-	QueueID             *string                    `json:"queueID"`      // no omitempty, queue id should not be empty
-	QueueName           string                     `json:"queueName"`    // no omitempty, queue name should not be empty
+	QueueID             *string                    `json:"queueID,omitempty"`
+	QueueName           string                     `json:"queueName"` // no omitempty, queue name should not be empty
 	SubmissionTime      int64                      `json:"submissionTime,omitempty"`
 	FinishedTime        *int64                     `json:"finishedTime,omitempty"`
 	Requests            []*AllocationAskDAOInfo    `json:"requests,omitempty"`


### PR DESCRIPTION
### What is this PR for?
Since each object now has IDs, we need to send the queue ID when serializing application dao.