### PR TITLE
Set PartitionID on root Queue objects

### DIFF
--- a/pkg/scheduler/objects/queue.go
+++ b/pkg/scheduler/objects/queue.go
@@ -138,7 +138,7 @@ func newBlankQueue() *Queue {
 
 // NewConfiguredQueue creates a new queue from scratch based on the configuration
 // lock free as it cannot be referenced yet
-func NewConfiguredQueue(conf configs.QueueConfig, parent *Queue) (*Queue, error) {
+func NewConfiguredQueue(conf configs.QueueConfig, parent *Queue, partitionID string) (*Queue, error) {
 	sq := newBlankQueue()
 	sq.Name = strings.ToLower(conf.Name)
 	sq.QueuePath = strings.ToLower(conf.Name)
@@ -165,6 +165,7 @@ func NewConfiguredQueue(conf configs.QueueConfig, parent *Queue) (*Queue, error)
 		}
 	} else {
 		sq.UpdateQueueProperties()
+		sq.PartitionID = partitionID
 	}
 	sq.queueEvents = schedEvt.NewQueueEvents(events.GetEventSystem())
 	log.Log(log.SchedQueue).Info("configured queue added to scheduler",
@@ -215,6 +216,7 @@ func newDynamicQueueInternal(name string, leaf bool, parent *Queue) (*Queue, err
 	sq := newBlankQueue()
 	sq.Name = strings.ToLower(name)
 	sq.QueuePath = parent.QueuePath + configs.DOT + sq.Name
+	sq.PartitionID = parent.PartitionID
 	sq.parent = parent
 	sq.isManaged = false
 	sq.isLeaf = leaf

--- a/pkg/scheduler/objects/queue_test.go
+++ b/pkg/scheduler/objects/queue_test.go
@@ -2216,9 +2216,10 @@ func TestNewConfiguredQueue(t *testing.T) {
 			},
 		},
 	}
-	parent, err := NewConfiguredQueue(parentConfig, nil)
+	parent, err := NewConfiguredQueue(parentConfig, nil, "1")
 	assert.NilError(t, err, "failed to create queue: %v", err)
 	assert.Equal(t, parent.Name, "parent_queue")
+	assert.Equal(t, parent.PartitionID, "1")
 	assert.Equal(t, parent.QueuePath, "parent_queue")
 	assert.Equal(t, parent.isManaged, true)
 	assert.Equal(t, parent.maxRunningApps, uint64(32))
@@ -2236,9 +2237,10 @@ func TestNewConfiguredQueue(t *testing.T) {
 			Guaranteed: getResourceConf(),
 		},
 	}
-	childLeaf, err := NewConfiguredQueue(leafConfig, parent)
+	childLeaf, err := NewConfiguredQueue(leafConfig, parent, "")
 	assert.NilError(t, err, "failed to create queue: %v", err)
 	assert.Equal(t, childLeaf.QueuePath, "parent_queue.leaf_queue")
+	assert.Equal(t, childLeaf.PartitionID, parent.PartitionID)
 	assert.Assert(t, childLeaf.template == nil)
 	assert.Assert(t, reflect.DeepEqual(childLeaf.properties, leafConfig.Properties))
 	childLeafMax, err := resources.NewResourceFromConf(leafConfig.Resources.Max)
@@ -2253,9 +2255,10 @@ func TestNewConfiguredQueue(t *testing.T) {
 		Name:   "nonleaf_queue",
 		Parent: true,
 	}
-	childNonLeaf, err := NewConfiguredQueue(NonLeafConfig, parent)
+	childNonLeaf, err := NewConfiguredQueue(NonLeafConfig, parent, "")
 	assert.NilError(t, err, "failed to create queue: %v", err)
 	assert.Equal(t, childNonLeaf.QueuePath, "parent_queue.nonleaf_queue")
+	assert.Equal(t, childLeaf.PartitionID, parent.PartitionID)
 	assert.Assert(t, reflect.DeepEqual(childNonLeaf.template, parent.template))
 	assert.Equal(t, len(childNonLeaf.properties), 0)
 	assert.Assert(t, childNonLeaf.guaranteedResource == nil)
@@ -2309,8 +2312,9 @@ func TestNewRecoveryQueue(t *testing.T) {
 		Properties:    map[string]string{configs.ApplicationSortPolicy: "fair"},
 		ChildTemplate: configs.ChildTemplate{Properties: map[string]string{configs.ApplicationSortPolicy: "fair"}},
 	}
-	parent, err = NewConfiguredQueue(parentConfig, nil)
+	parent, err = NewConfiguredQueue(parentConfig, nil, "2")
 	assert.NilError(t, err, "failed to create queue: %v", err)
+	assert.Equal(t, parent.PartitionID, "2")
 	recoveryQueue, err := NewRecoveryQueue(parent)
 	assert.NilError(t, err, "failed to create recovery queue: %v", err)
 	assert.Equal(t, common.RecoveryQueueFull, recoveryQueue.GetQueuePath(), "wrong queue name")

--- a/pkg/scheduler/objects/utilities_test.go
+++ b/pkg/scheduler/objects/utilities_test.go
@@ -91,7 +91,7 @@ func createManagedQueuePropsMaxApps(parentSQ *Queue, name string, parent bool, m
 			Guaranteed: guarRes,
 		}
 	}
-	queue, err := NewConfiguredQueue(queueConfig, parentSQ)
+	queue, err := NewConfiguredQueue(queueConfig, parentSQ, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scheduler/partition_test.go
+++ b/pkg/scheduler/partition_test.go
@@ -1529,7 +1529,7 @@ func TestGetQueue(t *testing.T) {
 	}
 	var parent *objects.Queue
 	// manually add the queue in below the root
-	parent, err = objects.NewConfiguredQueue(parentConf, queue)
+	parent, err = objects.NewConfiguredQueue(parentConf, queue, partition.ID)
 	assert.NilError(t, err, "failed to create parent queue")
 	queue = partition.GetQueue("root.unknown")
 	assert.Equal(t, queue, nilQueue, "partition returned not nil for non existing queue name request: %v", queue)

--- a/pkg/scheduler/placement/testrule_test.go
+++ b/pkg/scheduler/placement/testrule_test.go
@@ -78,7 +78,7 @@ func initQueueStructure(data []byte) error {
 		return err
 	}
 	rootConf := conf.Partitions[0].Queues[0]
-	root, err = objects.NewConfiguredQueue(rootConf, nil)
+	root, err = objects.NewConfiguredQueue(rootConf, nil, "1")
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func initQueueStructure(data []byte) error {
 
 func addQueue(conf []configs.QueueConfig, parent *objects.Queue) error {
 	for _, queueConf := range conf {
-		thisQueue, err := objects.NewConfiguredQueue(queueConf, parent)
+		thisQueue, err := objects.NewConfiguredQueue(queueConf, parent, "")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Add logic to get partition ID for the root queue and set the its PartitionID member; the root queue has no parent queue, so we can't simply have it inherit the parent's value.

Fixes https://github.com/G-Research/unicorn-history-server/issues/323