### PR TITLE
Yunikorn Core: fix for missing partition_id on NODE ADD/SET events

### DIFF
--- a/pkg/scheduler/context.go
+++ b/pkg/scheduler/context.go
@@ -595,7 +595,6 @@ func (cc *ClusterContext) removePartition(partitionName string) {
 // nil nodeInfo objects must be filtered out before calling this function
 func (cc *ClusterContext) addNode(nodeInfo *si.NodeInfo, schedulable bool) error {
 	sn := objects.NewNode(nodeInfo)
-	sn.SetSchedulable(schedulable)
 
 	partition := cc.GetPartition(sn.Partition)
 	if partition == nil {
@@ -608,6 +607,8 @@ func (cc *ClusterContext) addNode(nodeInfo *si.NodeInfo, schedulable bool) error
 		return err
 	}
 	sn.PartitionID = partition.ID
+
+	sn.SetSchedulable(schedulable)
 
 	err := partition.AddNode(sn)
 	sn.SendNodeAddedEvent()


### PR DESCRIPTION
When adding a node, call SetSchedulable() on it _after_ we've obtained its partition and set its PartitionID member - this is so the Node add/set event that is published will have its PartitionID populated.

Fixes https://github.com/G-Research/unicorn-history-server/issues/342