### PR TITLE
Add missing QueueID in the response.

### DIFF
--- a/pkg/webservice/handlers.go
+++ b/pkg/webservice/handlers.go
@@ -334,6 +334,7 @@ func getApplicationDAO(app *objects.Application, summary *objects.ApplicationSum
 		Partition:           common.GetPartitionNameWithoutClusterID(app.Partition),
 		PartitionID:         app.PartitionID,
 		QueueName:           app.GetQueuePath(),
+		QueueID:             app.DAO().QueueID,
 		SubmissionTime:      app.SubmissionTime.UnixNano(),
 		FinishedTime:        common.ZeroTimeInUnixNano(app.FinishedTime()),
 		Requests:            getAllocationAsksDAO(app.GetAllRequests()),


### PR DESCRIPTION
Add missing queueID in the API response.
related to https://github.com/G-Research/unicorn-history-server/issues/358
