### PR TITLE
fix: incorrect preemption due to pod count when ask needs to preemt more than 2 pods.

### DIFF
--- a/pkg/common/resources/resources.go
+++ b/pkg/common/resources/resources.go
@@ -922,6 +922,24 @@ func (r *Resource) StrictlyGreaterThanOnlyExisting(smaller *Resource) bool {
 	}
 }
 
+// FilterOutResourceTypes returns a new Resource with the specified resource types removed.
+func (r *Resource) FilterOutResourceTypes(resourceTypesToFilter ...string) *Resource {
+	if r == nil {
+		return NewResource()
+	}
+
+	filtered := r.Clone()
+	if len(resourceTypesToFilter) == 0 {
+		return filtered
+	}
+
+	for _, resourceType := range resourceTypesToFilter {
+		delete(filtered.Resources, resourceType)
+	}
+
+	return filtered
+}
+
 // Have at least one quantity > 0, and no quantities < 0
 // A nil resource is not strictly greater than zero.
 func StrictlyGreaterThanZero(larger *Resource) bool {

--- a/pkg/scheduler/objects/preemption.go
+++ b/pkg/scheduler/objects/preemption.go
@@ -858,11 +858,12 @@ func (p *Preemptor) TryPreemption() (*AllocationResult, bool) {
 			continue
 		}
 		// stop collecting the victims once ask resource requirement met
-		if p.ask.GetAllocatedResource().StrictlyGreaterThanOnlyExisting(victimsTotalResource) {
+		ask := p.ask.GetAllocatedResource().FilterOutResourceTypes("pods")
+		if ask.StrictlyGreaterThanOnlyExisting(victimsTotalResource) {
 			finalVictims = append(finalVictims, victim)
+			// add the victim resources to the total
+			victimsTotalResource.AddTo(victim.GetAllocatedResource())
 		}
-		// add the victim resources to the total
-		victimsTotalResource.AddTo(victim.GetAllocatedResource())
 	}
 
 	if p.ask.GetAllocatedResource().StrictlyGreaterThanOnlyExisting(victimsTotalResource) {

--- a/pkg/scheduler/objects/preemption_test.go
+++ b/pkg/scheduler/objects/preemption_test.go
@@ -1909,3 +1909,91 @@ func allocForScore(originator bool, allowPreemptSelf bool) *Allocation {
 		PreemptionPolicy: &si.PreemptionPolicy{AllowPreemptSelf: allowPreemptSelf},
 	})
 }
+
+// TestTryPreemption_LargeAskRequiresMultipleVictims Test preemption when a large ask requires multiple smaller victims to be preempted.
+// This test verifies that the victim selection logic correctly collects enough victims to satisfy the ask's resource requirements.
+//
+// Setup:
+// - Node1 has capacity: 1000 vcores, 1000 memory, 10 pods
+// - root.level1 parent queue with max resources: 800 vcores, 800 memory, 10 pods
+// - root.level1.child1 has guaranteed: 300 vcores, 300 memory, 3 pods
+//   - Contains 6 allocations (app1): each with 100 vcores, 100 memory, 1 pod
+//   - Total usage: 600 vcores, 600 memory, 6 pods (over-allocated beyond guarantee)
+//
+// - root.level1.child2 has guaranteed: 400 vcores, 400 memory, 5 pods
+//   - Has 1 ask waiting (app2): 300 vcores, 300 memory, 1 pod
+//
+// Expected behavior:
+// - child2's ask (300 vcores, 300 memory, 1 pod) triggers preemption
+// - Exactly 3 allocations from child1 are preempted (frees 300 vcores, 300 memory, 3 pods)
+// - This satisfies the ask's resource requirements while respecting guarantees
+// - The remaining 3 allocations in child1 are preserved to maintain the guaranteed quota
+//
+// Fixes: (YUNIKORN-3137) https://issues.apache.org/jira/browse/YUNIKORN-3137, Fails to preempt more than 2 victims for a larger ask.
+func TestTryPreemption_Ask_Needs_MultipleVictims_IgnorePodsCount(t *testing.T) {
+
+	node := newNode("node1", map[string]resources.Quantity{"vcore": 1000, "memory": 1000, "pods": 10})
+	iterator := getNodeIteratorFn(node)
+	rootQ, err := createRootQueue(map[string]string{"vcore": "1000", "memory": "1000", "pods": "10"})
+	assert.NilError(t, err)
+	parentQ, err := createManagedQueueGuaranteed(rootQ, "level1", true, map[string]string{"vcore": "800", "memory": "800", "pods": "10"}, nil)
+	assert.NilError(t, err)
+	childQ1, err := createManagedQueueGuaranteed(parentQ, "child1", false, nil, map[string]string{"vcore": "300", "memory": "300", "pods": "3"})
+	assert.NilError(t, err)
+	childQ2, err := createManagedQueueGuaranteed(parentQ, "child2", false, nil, map[string]string{"vcore": "400", "memory": "400", "pods": "5"})
+	assert.NilError(t, err)
+
+	app1 := newApplication(appID1, "default", "root.level1.child1")
+	app1.SetQueue(childQ1)
+	childQ1.applications[appID1] = app1
+
+	// Create 6 small allocations (100m CPU, 100Mi memory each)
+	victimAllocs := make([]*Allocation, 6)
+	for i := 0; i < 6; i++ {
+		ask := newAllocationAsk("alloc"+strconv.Itoa(i+1), appID1, resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 100, "memory": 100, "pods": 1}))
+		ask.createTime = time.Now().Add(-time.Duration(i+1) * time.Minute)
+		assert.NilError(t, app1.AddAllocationAsk(ask))
+
+		alloc := newAllocationWithKey("alloc"+strconv.Itoa(i+1), appID1, "node1", resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 100, "memory": 100, "pods": 1}))
+		alloc.createTime = ask.createTime
+		app1.AddAllocation(alloc)
+		assert.Check(t, node.TryAddAllocation(alloc), "node alloc failed")
+		assert.NilError(t, childQ1.TryIncAllocatedResource(ask.GetAllocatedResource()))
+		victimAllocs[i] = alloc
+	}
+
+	app2 := newApplication(appID2, "default", "root.level1.child2")
+	app2.SetQueue(childQ2)
+	childQ2.applications[appID2] = app2
+	ask3 := newAllocationAsk("alloc-large", appID2, resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 300, "memory": 300, "pods": 1}))
+	assert.NilError(t, app2.AddAllocationAsk(ask3))
+	childQ2.incPendingResource(ask3.GetAllocatedResource())
+
+	headRoom := resources.NewResourceFromMap(map[string]resources.Quantity{"vcore": 1000, "memory": 1000, "pods": 10})
+	preemptor := NewPreemptor(app2, headRoom, 30*time.Second, ask3, iterator(), false)
+
+	// Register predicate handler
+	allocs := map[string]string{}
+	allocs["alloc-large"] = "node1"
+
+	plugin := mock.NewPreemptionPredicatePlugin(nil, allocs, nil)
+	plugins.RegisterSchedulerPlugin(plugin)
+	defer plugins.UnregisterSchedulerPlugins()
+
+	result, ok := preemptor.TryPreemption()
+	assert.Assert(t, result != nil, "no result")
+	assert.NilError(t, plugin.GetPredicateError())
+	assert.Assert(t, ok, "no victims found")
+	assert.Equal(t, "alloc-large", result.Request.GetAllocationKey(), "wrong alloc")
+
+	// Verify that exactly 3 victims were preempted
+	preemptedCount := 0
+	for _, alloc := range victimAllocs {
+		if alloc.IsPreempted() {
+			preemptedCount++
+		}
+	}
+	assert.Equal(t, 3, preemptedCount, "wrong number of victims preempted")
+
+	assert.Equal(t, len(ask3.GetAllocationLog()), 0)
+}


### PR DESCRIPTION
Fixes https://github.com/G-Research/gr-oss/issues/1155

**There are two bugs here:**

1. `victimsTotalResource.AddTo(victim.GetAllocatedResource())` is placed **outside** the `if` statement, which causes `victimsTotalResource` to be miscalculated. As a result, the shortfall guard doesn’t block preemption as expected, leading to two pods being unnecessarily preempted even though preempting 2 is not sufficient to fit the ask.

2. `p.ask.GetAllocatedResource().StrictlyGreaterThanOnlyExisting(victimsTotalResource)` fails because the pod count becomes lower than the pod count in `victimsTotalResource`.

More details are available in this issue: https://github.com/G-Research/gr-oss/issues/1155

We need to ensure all items in `p.ask.GetAllocatedResource()` are greater than the corresponding items in the collected victims’ resource map. Additionally, we need to **ignore** any resources that exist in the victims map but not in the ask map.
I tried a few approaches using the comparison methods in `pkg/common/resources/resources.go`, such as collecting victims until any item in `victimsTotalResource` are less than the `p.ask.GetAllocatedResource()` etc., but those introduced side effects because we need to **ignore** any resources that are not in the ask map.

For now, the safest way to address bug 2, seems to be **ignoring pod counts** when comparing the ask with the victims’ allocation.

Manual test: https://github.com/sudiptob2/yunikorn-fairshare-tests/tree/main/z-preemption-fail-pod-count-with-gurantee
